### PR TITLE
electron-screenshots支持Electron10+

### DIFF
--- a/packages/electron-screenshots/src/screenshots.ts
+++ b/packages/electron-screenshots/src/screenshots.ts
@@ -94,7 +94,9 @@ export default class Screenshots extends Events {
       minimizable: false,
       maximizable: false,
       webPreferences: {
-        nodeIntegration: true
+        nodeIntegration: true,
+        enableRemoteModule: true,
+        contextIsolation: false
       }
     })
 


### PR DESCRIPTION
Electron10把enableRemoteModule默认值从true改为了false，加了contextIsolation默认值警告，这里覆盖一下默认值以支持新版的Electron